### PR TITLE
[추가한 파일]

### DIFF
--- a/src/main/java/kakaotech_bootcamp/team_21/coverletter_spring_project/config/WebConfig.java
+++ b/src/main/java/kakaotech_bootcamp/team_21/coverletter_spring_project/config/WebConfig.java
@@ -1,0 +1,26 @@
+package kakaotech_bootcamp.team_21.coverletter_spring_project.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+//나중에 스프링 시큐리티 써서 바꿔줘야함
+//cors 정책때문에 리액트(로컬호스트 3000번) 에서 오는 요청 전부 거절당해서 만든 파일
+//나중에 배포시에는 링크 수정해야함
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/src/main/java/kakaotech_bootcamp/team_21/coverletter_spring_project/datainitializer/UsersTableInitializer.sql
+++ b/src/main/java/kakaotech_bootcamp/team_21/coverletter_spring_project/datainitializer/UsersTableInitializer.sql
@@ -1,0 +1,18 @@
+-- USERS 테이블 생성, 요한이가 만들어둔 데이터 이니셜라이져가 테이블만 만들어주고 데이터 반영이 안되서 따로 만듬
+-- 스프링 실행시 자동으로 실행됩지는 않으므로 h2 콘솔에서 복사해서 직접 실행해야 테이블 만들어지고 데이터 들어감
+CREATE TABLE USERS (
+    user_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) NOT NULL,
+    nickname VARCHAR(255),
+    img VARCHAR(255),
+    role VARCHAR(50),
+    profile TEXT,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL
+);
+
+-- 데이터 삽입
+INSERT INTO USERS (username, nickname, img, role, profile, email, password) VALUES
+('yohan', 'water', NULL, 'USER', '저는 워터입니다.', 'kakao1@naver.com', '1234'),
+('hanyo', 'whater', NULL, 'USER', '저는 와터입니다.', 'kakao2@naver.com', '2345'),
+('kakao', 'winter', NULL, 'USER', '저는 카카오입니다.', 'kakao3@naver.com', '3456'); 이거를 데이터이니셜라이져 폴더에 넣으려고 하는데 적당한 파일이름 추천좀


### PR DESCRIPTION
UsersTableInitializer.sql
WebConfig
요한이가 만든 데이터 이니셜라이저가 유저 테이블은 안만들어줘서 sql 쿼리문 작성해서 h2 콘솔에서 쿼리문 실행해서 직접 넣는 방식으로 했어.
WebConfig는 cors 정책 막히는거 막을려고 만든거야.